### PR TITLE
Use case sensitive filenames for SDL library loading

### DIFF
--- a/anima.carp
+++ b/anima.carp
@@ -1,5 +1,5 @@
-(load "sdl.carp")
-(load "sdl_image.carp")
+(load "SDL.carp")
+(load "SDL_image.carp")
 (load "Vector.carp")
 
 (use-all Vector2)


### PR DESCRIPTION
The library files for SDL.carp and SDL_image.carp need the
correct case to work on case sensitive file systems.